### PR TITLE
Add theme customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,31 @@
 
 # Hexagon
 
-A minimalist zsh theme based on [geometry](https://github.com/geometry-zsh/geometry).
+> a minimalist zsh prompt theme inspired by [geometry](https://github.com/geometry-zsh/geometry), fast *by design*.
 
-## Installing
+At a glance, you see what matters. Nothing else clutters your prompt.
 
-Add `zplug "diogoazevedos/hexagon"` to your `~/.zshrc`.
+- Current branch, tag, or short commit SHA
+- Clean ⬢ or dirty ⬡ working tree
+- Commits ⇡ ahead or ⇣ behind upstream
+- Time since the last commit
+- Elapsed time on long-running commands
+- Background job count
+
+## Install
+
+### [antidote](https://antidote.sh) *(recommended)*
+
+Add this to your `~/.zsh_plugins.txt`:
+
+```
+dio-az/hexagon
+```
+
+### [zplug](https://github.com/zplug/zplug)
+
+Add this to your `~/.zshrc`:
+
+```sh
+zplug "dio-az/hexagon"
+```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,148 @@ Add this to your `~/.zshrc`:
 ```sh
 zplug "dio-az/hexagon"
 ```
+
+## Styling
+
+Hexagon uses `zstyle` for configuration. The general format is:
+
+```zsh
+zstyle ':hexagon:context' property value
+```
+
+For example, to change the path color to cyan:
+
+```zsh
+zstyle ':hexagon:path' color cyan
+```
+
+### Prompt path
+
+The path on the left is yours to style:
+
+| Context         | Property | Default | Description                                    |
+| --------------- | -------- | ------- | ---------------------------------------------- |
+| `:hexagon:path` | `color`  | `blue`  | Left-prompt path color                         |
+| `:hexagon:path` | `format` | `%2~`   | Left-prompt path format (zsh prompt expansion) |
+
+### Components
+
+Add, drop, or rearrange the right-prompt pieces:
+
+| Context    | Property     | Default          | Description                       |
+| ---------- | ------------ | ---------------- | --------------------------------- |
+| `:hexagon` | `components` | `timer jobs git` | Right-prompt components, in order |
+
+### Timer
+
+Slow commands quietly show how long they took:
+
+| Context          | Property    | Default | Description                                             |
+| ---------------- | ----------- | ------- | ------------------------------------------------------- |
+| `:hexagon:timer` | `threshold` | `5`     | Seconds a command must run before elapsed time is shown |
+
+### Duration
+
+Customize the color of the durations shown by git elapsed and timer:
+
+| Context                    | Property | Default | Description                      |
+| -------------------------- | -------- | ------- | -------------------------------- |
+| `:hexagon:duration:day`    | `color`  | `red`   | Color for day-scale durations    |
+| `:hexagon:duration:hour`   | `color`  | `white` | Color for hour-scale durations   |
+| `:hexagon:duration:minute` | `color`  | `green` | Color for minute-scale durations |
+| `:hexagon:duration:second` | `color`  | `green` | Color for second-scale durations |
+
+### Jobs
+
+See how many background jobs are running:
+
+| Context         | Property | Default | Description                         |
+| --------------- | -------- | ------- | ----------------------------------- |
+| `:hexagon:jobs` | `color`  | `blue`  | Job count color                     |
+| `:hexagon:jobs` | `symbol` | `⚙`     | Symbol rendered after the job count |
+
+### Git
+
+Inside a repo, see your branch, working-tree state, and upstream tracking:
+
+| Context                     | Property     | Default                        | Description                                  |
+| --------------------------- | ------------ | ------------------------------ | -------------------------------------------- |
+| `:hexagon:git`              | `components` | `remote branch elapsed status` | Git sub-components, in order                 |
+| `:hexagon:git:branch`       | `color`      | `242`                          | Branch, tag, or short SHA color              |
+| `:hexagon:git:status:clean` | `color`      | `green`                        | Status indicator color when tree is clean    |
+| `:hexagon:git:status:clean` | `symbol`     | `⬢`                            | Status symbol when tree is clean             |
+| `:hexagon:git:status:dirty` | `color`      | `red`                          | Status indicator color when tree has changes |
+| `:hexagon:git:status:dirty` | `symbol`     | `⬡`                            | Status symbol when tree has changes          |
+| `:hexagon:git:remote`       | `color`      | `default`                      | Ahead/behind indicator color                 |
+| `:hexagon:git:remote`       | `ahead`      | `⇡`                            | Symbol shown when ahead of upstream          |
+| `:hexagon:git:remote`       | `behind`     | `⇣`                            | Symbol shown when behind upstream            |
+
+## Custom components
+
+A component is a shell function named `hexagon_<name>` that writes its output to `stdout`.
+
+> [!TIP]
+> Return without printing anything to hide the component.
+
+Register custom components by adding them to `:hexagon` `components`:
+
+```zsh
+zstyle ':hexagon' components <name>
+```
+
+The following helper functions are available:
+
+| Helper                                                 | Description                                                           |
+| ------------------------------------------------------ | --------------------------------------------------------------------- |
+| `hexagon::color <color> <text>`                        | Wrap `text` in a `%F{color}text%f` prompt escape                      |
+| `hexagon::style -s <context> <property> <default>`     | Read a scalar `zstyle` into `$<property>`, defaulting to `<default>`  |
+| `hexagon::style -a <context> <property> <defaults...>` | Like `-s`, but for array styles                                       |
+| `hexagon::duration <seconds>`                          | Format a duration label (`5s`, `3m`), styled by `:hexagon:duration:*` |
+
+Here is a component that shows the active Node.js version:
+
+```zsh
+hexagon_node() {
+	command -v node &>/dev/null || return
+
+	local color symbol
+	hexagon::style -s ':hexagon:node' color green
+	hexagon::style -s ':hexagon:node' symbol ⬡
+
+	hexagon::color $color $symbol$(node --version)
+}
+
+zstyle ':hexagon' components node timer jobs git
+```
+
+Place this in your `~/.zshrc` *after* loading Hexagon.
+
+### Git components
+
+Like a regular component, but its function is named `hexagon_git_<name>`, registered under `:hexagon:git` `components`, and called only inside a git repository. Before it runs, the `$hexagon_git` associative array is populated with:
+
+| Key                        | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `hexagon_git[branch]`      | Branch name; tag or 7-character SHA when detached                   |
+| `hexagon_git[sha]`         | Full commit SHA of `HEAD`, or `(initial)` in a repo with no commits |
+| `hexagon_git[ahead]`       | Commits ahead of upstream, or empty when there's no upstream        |
+| `hexagon_git[behind]`      | Commits behind upstream, or empty when there's no upstream          |
+| `hexagon_git[dirty]`       | `1` when the working tree is dirty, otherwise empty                 |
+| `hexagon_git[commit_time]` | Unix timestamp of the most recent commit, or empty in a fresh repo  |
+| `hexagon_git[stash]`       | Number of stashes, or empty when none                               |
+
+Here is a component that shows the stash count:
+
+```zsh
+hexagon_git_stash() {
+	(( hexagon_git[stash] == 0 )) && return
+
+	local color symbol
+	hexagon::style -s ':hexagon:git:stash' color 242
+	hexagon::style -s ':hexagon:git:stash' symbol ≡
+
+	hexagon::color $color $hexagon_git[stash]$symbol
+}
+
+zstyle ':hexagon:git' components remote branch elapsed status stash
+```

--- a/hexagon.zsh
+++ b/hexagon.zsh
@@ -2,26 +2,38 @@ autoload -U add-zsh-hook
 
 ZLE_RPROMPT_INDENT=0
 
+hexagon::style() {
+	zstyle $@[1,3] $3 && return
+	[[ $1 == -a ]] && set -A $3 ${@:4} || : ${(P)3::=$4}
+}
+
 hexagon::color() {
 	(($# - 2)) || echo -n %F{$1}$2%f
 }
 
-hexagon::format() {
+hexagon::duration() {
 	local seconds=$1
 	local days=$((seconds / 86400))
 	local hours=$((seconds / 3600 % 24))
 	local minutes=$((seconds / 60 % 60))
 	local seconds=$((seconds % 60))
 
-	local -a human=()
-	local color
+	local color label
+	if ((days > 0)); then
+		hexagon::style -s ':hexagon:duration:day' color red
+		label=${days}d
+	elif ((hours > 0)); then
+		hexagon::style -s ':hexagon:duration:hour' color white
+		label=${hours}h
+	elif ((minutes > 0)); then
+		hexagon::style -s ':hexagon:duration:minute' color green
+		label=${minutes}m
+	elif ((seconds > 0)); then
+		hexagon::style -s ':hexagon:duration:second' color green
+		label=${seconds}s
+	fi
 
-	((days > 0)) && human+=${days}d && color=red
-	((hours > 0)) && human+=${hours}h && : ${color:=white}
-	((minutes > 0)) && human+=${minutes}m
-	((seconds > 0)) && human+=${seconds}s && : ${color:=green}
-
-	hexagon::color $color $human[1]
+	hexagon::color $color $label
 }
 
 zmodload zsh/datetime
@@ -35,43 +47,66 @@ add-zsh-hook preexec hexagon::command_start
 hexagon_timer() {
 	[[ -n $hexagon_command_start ]] || return
 
+	local threshold
+	hexagon::style -s ':hexagon:timer' threshold 5
+
 	local elapsed=$(( EPOCHSECONDS - hexagon_command_start ))
-	((elapsed > 5)) && hexagon::format $elapsed
+	((elapsed > threshold)) && hexagon::duration $elapsed
 }
 
 hexagon_jobs() {
-	(( $#jobstates )) && hexagon::color blue '⚙ %(1j.%j.-)'
+	(( $#jobstates )) || return
+
+	local color symbol
+	hexagon::style -s ':hexagon:jobs' color blue
+	hexagon::style -s ':hexagon:jobs' symbol ⚙
+
+	hexagon::color $color "%(1j.%j.-)$symbol"
 }
 
-hexagon_git_time() {
-	[[ -z $hexagon_git[commit_time] ]] && hexagon::color default welcome && return
+hexagon_git_elapsed() {
+	[[ -n $hexagon_git[commit_time] ]] || return
 
 	local seconds_since_last_commit=$((EPOCHSECONDS - hexagon_git[commit_time]))
-
-	hexagon::format $seconds_since_last_commit
+	hexagon::duration $seconds_since_last_commit
 }
 
-hexagon_git_head() {
-	hexagon::color 242 $hexagon_git[head]
+hexagon_git_branch() {
+	local color
+	hexagon::style -s ':hexagon:git:branch' color 242
+
+	hexagon::color $color $hexagon_git[branch]
 }
 
 hexagon_git_status() {
-	[[ -z $hexagon_git[dirty] ]] && hexagon::color green ⬢ || hexagon::color red ⬡
+	local color symbol
+	if [[ -n $hexagon_git[dirty] ]]; then
+		hexagon::style -s ':hexagon:git:status:dirty' color red
+		hexagon::style -s ':hexagon:git:status:dirty' symbol ⬡
+	else
+		hexagon::style -s ':hexagon:git:status:clean' color green
+		hexagon::style -s ':hexagon:git:status:clean' symbol ⬢
+	fi
+
+	hexagon::color $color $symbol
 }
 
 hexagon_git_remote() {
-	local unpushed=⇡
-	local unpulled=⇣
-
 	(( hexagon_git[ahead] == 0 && hexagon_git[behind] == 0 )) && return
-	(( hexagon_git[behind] == 0 )) && echo -n $unpushed && return
-	(( hexagon_git[ahead] == 0 )) && echo -n $unpulled && return
 
-	echo -n $unpushed $unpulled
+	local ahead behind color
+	hexagon::style -s ':hexagon:git:remote' ahead ⇡
+	hexagon::style -s ':hexagon:git:remote' behind ⇣
+	hexagon::style -s ':hexagon:git:remote' color default
+
+	(( hexagon_git[behind] == 0 )) && hexagon::color $color $ahead && return
+	(( hexagon_git[ahead] == 0 )) && hexagon::color $color $behind && return
+
+	hexagon::color $color "$ahead $behind"
 }
 
 hexagon_git() {
-	local report=$(git status --porcelain=v2 --branch --ignore-submodules 2>/dev/null)
+	local report=$(git status --porcelain=v2 --branch --show-stash --ignore-submodules 2>/dev/null)
 
 	[[ -z $report ]] && return
 
@@ -80,41 +115,61 @@ hexagon_git() {
 	local line
 	for line in ${(f)report}; do
 		case $line in
-			'# branch.head '*) hexagon_git[head]=${line#'# branch.head '} ;;
+			'# branch.head '*) hexagon_git[branch]=${line#'# branch.head '} ;;
 			'# branch.oid '*) hexagon_git[sha]=${line#'# branch.oid '} ;;
 			'# branch.ab '*)
 				local ab=${line#'# branch.ab +'}
 				hexagon_git[ahead]=${ab%% -*}
 				hexagon_git[behind]=${ab##*-}
 				;;
+			'# stash '*) hexagon_git[stash]=${line#'# stash '} ;;
 			'# '*) ;;
 			'1 '?'.'* | '2 '?'.'*) ;;
 			*) hexagon_git[dirty]=1; break ;;
 		esac
 	done
 
-	if [[ $hexagon_git[head] == '(detached)' ]]; then
+	if [[ $hexagon_git[branch] == '(detached)' ]]; then
 		local tag=$(git describe --tags --exact-match 2>/dev/null)
-		hexagon_git[head]=${tag:-${hexagon_git[sha][1,7]}}
+		hexagon_git[branch]=${tag:-${hexagon_git[sha][1,7]}}
 	fi
 
 	hexagon_git[commit_time]=$(git log -1 --format=%ct 2>/dev/null)
 
-	echo -n $(hexagon_git_remote) $(hexagon_git_head) $(hexagon_git_time) $(hexagon_git_status)
+	local -a components
+	hexagon::style -a ':hexagon:git' components remote branch elapsed status
+
+	local -a output=()
+
+	local component
+	for component in $components; do
+		local result=$(hexagon_git_$component)
+		[[ -n $result ]] && output+=$result
+	done
+
+	echo -n ${(j: :)output}
 }
 
 hexagon::render() {
-	local -a output=(
-		$(hexagon_timer)
-		$(hexagon_jobs)
-		$(hexagon_git)
-	)
+	local -a components
+	hexagon::style -a ':hexagon' components timer jobs git
+
+	local -a output=()
+
+	local component
+	for component in $components; do
+		local result=$(hexagon_$component)
+		[[ -n $result ]] && output+=$result
+	done
 
 	unset hexagon_command_start
 
-	RPROMPT=${(ps: :)output}
-}
+	local color format
+	hexagon::style -s ':hexagon:path' color blue
+	hexagon::style -s ':hexagon:path' format %2~
 
-PROMPT=$(hexagon::color blue "%2~ ")
+	PROMPT="$(hexagon::color $color $format) "
+	RPROMPT=${(j: :)output}
+}
 
 add-zsh-hook precmd hexagon::render


### PR DESCRIPTION
Makes every color, symbol, threshold, and component slot customizable via `zstyle` 🎉

Additionally, exposes an API so you can write your own components. The `hexagon::color`, `hexagon::style`, and `hexagon::duration` helpers are available. Check the [custom components](https://github.com/dio-az/hexagon/blob/fda513932a67d9e20208b5a3608277e733d11a0c/README.md#custom-components) for more.

Removes the `welcome` label for fresh repos.