### PR TITLE
Escape branch/tag names instead of stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,13 @@ The following helper functions are available:
 | Helper                                                 | Description                                                           |
 | ------------------------------------------------------ | --------------------------------------------------------------------- |
 | `hexagon::color <color> <text>`                        | Wrap `text` in a `%F{color}text%f` prompt escape                      |
+| `hexagon::escape <text>`                               | Neutralize prompt metacharacters (`%`, `!`, `$`, `` ` ``, `\`)        |
 | `hexagon::style -s <context> <property> <default>`     | Read a scalar `zstyle` into `$<property>`, defaulting to `<default>`  |
 | `hexagon::style -a <context> <property> <defaults...>` | Like `-s`, but for array styles                                       |
 | `hexagon::duration <seconds>`                          | Format a duration label (`5s`, `3m`), styled by `:hexagon:duration:*` |
+
+> [!IMPORTANT]
+> Always run untrusted text through `hexagon::escape` before printing it, or it can hijack the prompt and run arbitrary commands.
 
 Here is a component that shows the active major Node.js version:
 

--- a/hexagon.zsh
+++ b/hexagon.zsh
@@ -7,12 +7,18 @@ hexagon::style() {
 	[[ $1 == -a ]] && set -A $3 ${@:4} || : ${(P)3::=$4}
 }
 
-hexagon::sanitize() {
-	print -n -- ${${1//'$'/}//\`/}
+hexagon::escape() {
+	local text=$1
+	text=${text//'\'/'\\'}
+	text=${text//'$'/'\$'}
+	text=${text//'`'/'\`'}
+	text=${text//'%'/'%%'}
+	text=${text//'!'/'!!'}
+	print -rn -- $text
 }
 
 hexagon::color() {
-	(($# == 2)) && print -n %F{$1}$2%f
+	(($# == 2)) && print -rn -- %F{$1}$2%f
 }
 
 hexagon::duration() {
@@ -119,7 +125,7 @@ hexagon_git() {
 	local line
 	for line in ${(f)report}; do
 		case $line in
-			'# branch.head '*) hexagon_git[branch]=$(hexagon::sanitize ${line#'# branch.head '}) ;;
+			'# branch.head '*) hexagon_git[branch]=$(hexagon::escape ${line#'# branch.head '}) ;;
 			'# branch.oid '*) hexagon_git[sha]=${line#'# branch.oid '} ;;
 			'# branch.ab '*)
 				local ab=${line#'# branch.ab +'}
@@ -135,7 +141,7 @@ hexagon_git() {
 
 	if [[ $hexagon_git[branch] == '(detached)' ]]; then
 		local tag=$(git describe --tags --exact-match 2>/dev/null)
-		hexagon_git[branch]=$(hexagon::sanitize ${tag:-${hexagon_git[sha][1,7]}})
+		hexagon_git[branch]=$(hexagon::escape ${tag:-${hexagon_git[sha][1,7]}})
 	fi
 
 	hexagon_git[commit_time]=$(git log -1 --format=%ct 2>/dev/null)
@@ -150,7 +156,7 @@ hexagon_git() {
 		done
 	)
 
-	print -n ${(j: :)${(0)output}}
+	print -rn -- ${(j: :)${(0)output}}
 }
 
 hexagon::render() {


### PR DESCRIPTION
Escapes prompt metacharacters (`%`, `!`, `$`, backticks, `\`) in git branch/tag names instead of stripping, so they render verbatim.