### PR TITLE
Add exit code indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ At a glance, you see what matters. Nothing else clutters your prompt.
 - Time since the last commit
 - Elapsed time on long-running commands
 - Background job count
+- Exit code of the previous command when it fails
 
 ## Install
 
@@ -87,6 +88,24 @@ See how many background jobs are running:
 | --------------- | -------- | ------- | ----------------------------------- |
 | `:hexagon:jobs` | `color`  | `blue`  | Job count color                     |
 | `:hexagon:jobs` | `symbol` | `⚙`     | Symbol rendered after the job count |
+
+### Exit
+
+When the previous command fails, see its exit code:
+
+| Context         | Property | Default | Description                          |
+| --------------- | -------- | ------- | ------------------------------------ |
+| `:hexagon:exit` | `color`  | `red`   | Exit code color                      |
+| `:hexagon:exit` | `symbol` | `‣`     | Symbol rendered before the exit code |
+
+> [!NOTE]
+> The `exit` component is not enabled by default. Add it to your [components](#components):
+>
+> ```zsh
+> zstyle ':hexagon' components exit timer jobs git
+> ```
+>
+> The indicator is hidden for `0` (success), `130` (Ctrl-C), and `141` (SIGPIPE).
 
 ### Git
 

--- a/hexagon.zsh
+++ b/hexagon.zsh
@@ -164,7 +164,19 @@ hexagon_git() {
 	print -rn -- ${(j: :)${(0)output}}
 }
 
+hexagon_exit() {
+	[[ $exit_code == (0|130|141) ]] && return
+
+	local symbol color
+	hexagon::style -s ':hexagon:exit' symbol ‣
+	hexagon::style -s ':hexagon:exit' color red
+
+	hexagon::color $color $symbol$exit_code
+}
+
 hexagon::render() {
+	local exit_code=$?
+
 	local -a components
 	hexagon::style -a ':hexagon' components timer jobs git
 


### PR DESCRIPTION
Adds `exit` component that shows the previous command's exit code in the prompt.